### PR TITLE
Allow for empty translation and return zero

### DIFF
--- a/chrF++.py
+++ b/chrF++.py
@@ -125,10 +125,7 @@ def computeChrF(fpRef, fpHyp, nworder, ncorder, beta, sentence_level_scores = No
         nsent += 1
         
         # preparation for multiple references
-        maxF = 0.0
-        bestWordMatchingCount = None
-        bestCharMatchingCount = None
-        
+        maxF = -1.0
         hypNgramCounts = ngram_counts(separate_punctuation(hline), nworder)
         hypChrNgramCounts = ngram_counts(separate_characters(hline), ncorder)
 


### PR DESCRIPTION
Allow to have an empty translation when calculate chrF. Also deleting unused variables. 


```
> python ../chrF/chrF++.py -R non_empty -H empty
start_time:     1567508841
c6+w2-F2        0.0000
c6+w2-avgF2     0.0000
end_time:       1567508841

> cat empty

> cat non_empty
Prijevod

```

Without this change there was this error:
```
> python ../mychange/chrF/chrF++.py -R non_empty -H empty
start_time:     1567508961
Traceback (most recent call last):
  File "../mychange/chrF/chrF++.py", line 229, in <module>
    main()
  File "../mychange/chrF/chrF++.py", line 215, in main
    totalF, averageTotalF, totalPrec, totalRec = computeChrF(rtxt, htxt, args.nworder, args.ncorder, args.beta, sentence_level_scores)
  File "../mychange/chrF/chrF++.py", line 170, in computeChrF
    totalMatchingCount[order] += bestMatchingCount[order]
UnboundLocalError: local variable 'bestMatchingCount' referenced before assignment
```